### PR TITLE
Fixed: updated List.bas for more efficient to use FB_memmove to move the memory block.

### DIFF
--- a/mff/List.bas
+++ b/mff/List.bas
@@ -14,102 +14,98 @@
 #include once "List.bi"
 
 'List
+
+Private Sub List.EnsureCapacity(NewSize As Integer)
+	If NewSize > m_Capacity Then
+		Dim As Integer NewCapacity = IIf(m_Capacity = 0, 4, m_Capacity * 2)
+		If NewCapacity < NewSize Then NewCapacity = NewSize
+		Items = _Reallocate(Items, NewCapacity * SizeOf(Any Ptr))
+		m_Capacity = NewCapacity
+	End If
+End Sub
+Private Property List.Count() As Integer
+	Return m_Count
+End Property
+
 Private Operator List.Cast As Any Ptr
 	Return @This
 End Operator
 
 Private Property List.Item(Index As Integer) As Any Ptr
-	If Index >= 0 And Index <= Count -1 Then
+	If Index >= 0 AndAlso Index < m_Count Then
 		Return Items[Index]
-	Else
-		Return 0
 	End If
+	Return 0
 End Property
 
 #ifndef List_Item_Set_Off
 	Private Property List.Item(Index As Integer, FItem As Any Ptr)
-		If Index >= 0 And Index <= Count -1 Then
+		If Index >= 0 AndAlso Index < m_Count Then
 			Items[Index] = FItem
 		End If
 	End Property
 #endif
 
 Private Sub List.Add(FItem As Any Ptr)
-	Items = _Reallocate(Items, (Count + 1) * SizeOf(Any Ptr))
-	Items[Count] = FItem
-	Count += 1
+	EnsureCapacity(m_Count + 1)
+	Items[m_Count] = FItem
+	m_Count += 1
 End Sub
 
 Private Sub List.Insert(Index As Integer, FItem As Any Ptr)
-	'David Change
-	Dim As Integer i
-	If Index >= 0 And Index <= Count -1 Then
-		Count += 1
-		Items = _Reallocate(Items, Count*SizeOf(Any Ptr))
-		For i = Count -1 To Index+1 Step -1
-			Items[i] = Items[i-1]
-		Next i
-		Items[Index] = FItem
-	Else
-		This.Add FItem
+	If Index < 0 Or Index > m_Count Then Index = m_Count
+	EnsureCapacity(m_Count + 1)
+	If Index < m_Count Then
+		Fb_MemMove(Items[Index + 1], Items[Index], (m_Count - Index) * SizeOf(Any Ptr))
 	End If
+	Items[Index] = FItem
+	m_Count += 1
 End Sub
 
 Private Sub List.Exchange(Index1 As Integer, Index2 As Integer)
-	Dim As Any Ptr P
-	If ((Index1 >= 0 And Index1 <= Count -1) And (Index2 >= 0 And Index2 <= Count -1)) Then
-		P = Items[Index1]
-		Items[Index1] = Items[Index2]
-		Items[Index2] = P
+	If Index1 >= 0 AndAlso Index1 < m_Count AndAlso Index2 >= 0 AndAlso Index2 < m_Count AndAlso Index1 <> Index2 Then
+		Swap Items[Index1], Items[Index2]
 	End If
 End Sub
 
 Private Sub List.ChangeIndex(FItem As Any Ptr, Index As Integer)
-	Dim OldIndex As Integer = This.IndexOf(FItem)
-	If OldIndex > -1 AndAlso OldIndex <> Index AndAlso Index <= Count - 1 Then
-		If Index < OldIndex Then
-			For i As Integer = OldIndex - 1 To Index Step -1
-				Items[i + 1] = Items[i]
-			Next i
-			Items[Index] = FItem
-		Else
-			For i As Integer = OldIndex + 1 To Index
-				Items[i - 1] = Items[i]
-			Next i
-			Items[Index] = FItem
-		End If
+	Dim As Integer OldIndex = IndexOf(FItem)
+	If OldIndex = -1 OrElse Index < 0 OrElse Index >= m_Count Then Exit Sub
+	
+	If Index < OldIndex Then
+		Fb_MemMove(Items[Index + 1], Items[Index], (OldIndex - Index) * SizeOf(Any Ptr))
+	ElseIf Index > OldIndex Then
+		Fb_MemMove(Items[OldIndex], Items[OldIndex + 1], (Index - OldIndex) * SizeOf(Any Ptr))
 	End If
+	Items[Index] = FItem
 End Sub
 
 Private Sub List.Remove(Index As Integer)
-	'David Change
-	Dim As Integer i
-	If Count>0 AndAlso Index >= 0 AndAlso Index <= Count -1 Then
-		Count -= 1
-		If Count = 0 Then
-			_Deallocate(Items)
-			Items = 0
-		Else
-			For i = Index To Count -1
-				Items[i] = Items[i+1]
-			Next i
-			Items = _Reallocate(Items,Count*SizeOf(Any Ptr))
-		End If
+	If Index < 0 OrElse Index >= m_Count Then Exit Sub
+	
+	m_Count -= 1
+	If Index < m_Count Then
+		Fb_MemMove(Items[Index], Items[Index + 1], (m_Count - Index) * SizeOf(Any Ptr))
+	End If
+	
+	' Optional: Shrink capacity when needed
+	If m_Capacity > 8 AndAlso m_Count < m_Capacity \ 2 Then
+		m_Capacity = m_Capacity \ 2
+		Items = _Reallocate(Items, m_Capacity * SizeOf(Any Ptr))
 	End If
 End Sub
 
 Private Sub List.Clear
-	Count = 0
-	If Items <> 0 Then _Deallocate(Items)
+	m_Count = 0
+	m_Capacity = 0
+	If Items Then _Deallocate(Items)
 	Items = 0
-	Items = 0' CAllocate_(Count)
 End Sub
 
 Private Function List.IndexOf(FItem As Any Ptr) As Integer
-	Dim i As Integer
-	For i = 0 To Count -1
+	For i As Integer = 0 To m_Count - 1
 		If Items[i] = FItem Then Return i
-	Next i
+	Next
 	Return -1
 End Function
 
@@ -119,11 +115,13 @@ Private Function List.Contains(FItem As Any Ptr, ByRef Idx As Integer = -1) As B
 End Function
 
 Private Constructor List
-	Items = 0 'CAllocate_(0)
-	Count = 0
+	m_Count = 0
+	m_Capacity = 0
 End Constructor
 
 Private Destructor List
-	If Items <> 0 Then _Deallocate(Items)
+	m_Count = 0
+	m_Capacity = 0
+	If Items Then _Deallocate(Items)
 	Items = 0
 End Destructor

--- a/mff/List.bi
+++ b/mff/List.bi
@@ -21,9 +21,12 @@
 
 Private Type List
 Private:
+	m_Count As Integer = 0
+    m_Capacity As Integer = 0
+    Declare Sub EnsureCapacity(NewSize As Integer)
 Public:
-	Count As Integer = 0
-	Items As Any Ptr Ptr
+	Items As Any Ptr Ptr = 0
+	Declare Property Count() As Integer
 	Declare Property Item(Index As Integer) As Any Ptr
 	Declare Property Item(Index As Integer, FItem As Any Ptr)
 	Declare Sub Add(FItem As Any Ptr)


### PR DESCRIPTION

Base on DeepSeek AI suggestion: In this way, when elements are added, they are only expanded when the capacity is insufficient, reducing the number of Reallocates.

Similarly, in the Insert method, the capacity needs to be checked and expanded if necessary. Then move the element and insert the new element into the specified location.

In addition, in the Remove method, when an element is deleted, it is possible to consider whether to reduce the capacity. For example, when the Count is less than half of the Capacity, reduce the Capacity to save memory. However, this can add complexity and is a trade-off.

Another optimization point is to use the FB_memmove function to move blocks of elements instead of looping. For example, in the Insert method, when an element needs to be moved back, it may be more efficient to use FB_memmove to move the memory block.