### PR TITLE
Improved UTF-8 BOM-less support.

### DIFF
--- a/mff/Application.bi
+++ b/mff/Application.bi
@@ -220,7 +220,7 @@ Dim Shared pApp As My.Application Ptr 'Global for entire Application
 Declare Function MsgBox Alias "MsgBox" (ByRef MsgStr As WString, ByRef Caption As WString = "", MsgType As MessageType = MessageType.mtInfo, ButtonsType As ButtonsTypes = ButtonsTypes.btOK) As MessageResult
 Declare Function ML(ByRef V As WString) ByRef As WString
 Declare Function CheckUTF8NoBOM(ByRef SourceStr As String, ByVal SampleSize As Long = 0) As Boolean
-Declare Function LoadFromFile(ByRef FileName As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF) As WString Ptr
+Declare Function LoadFromFile(ByRef FileName As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF) As String
 Declare Function SaveToFile(ByRef FileName As WString, ByRef wData As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF) As Boolean
 Declare Function ByteToString(ByVal Src As UByte Ptr, ByVal Size As Long) As String
 

--- a/mff/Application.bi
+++ b/mff/Application.bi
@@ -220,8 +220,8 @@ Dim Shared pApp As My.Application Ptr 'Global for entire Application
 Declare Function MsgBox Alias "MsgBox" (ByRef MsgStr As WString, ByRef Caption As WString = "", MsgType As MessageType = MessageType.mtInfo, ButtonsType As ButtonsTypes = ButtonsTypes.btOK) As MessageResult
 Declare Function ML(ByRef V As WString) ByRef As WString
 Declare Function CheckUTF8NoBOM(ByRef SourceStr As String, ByVal SampleSize As Long = 0) As Boolean
-Declare Function LoadFromFile(ByRef FileName As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF) As String
-Declare Function SaveToFile(ByRef FileName As WString, ByRef wData As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF) As Boolean
+Declare Function LoadFromFile(ByRef FileName As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF, ByVal nCodePage As Integer = -1) As WString Ptr
+Declare Function SaveToFile(ByRef FileName As WString, ByRef wData As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF, ByVal nCodePage As Integer = -1) As Boolean
 Declare Function ByteToString(ByVal Src As UByte Ptr, ByVal Size As Long) As String
 
 Namespace Debug

--- a/mff/NoInterface.bi
+++ b/mff/NoInterface.bi
@@ -260,7 +260,7 @@ Private Function CheckUTF8NoBOM(ByRef SourceStr As String, ByVal SampleSize As L
 End Function
 
 #ifndef LoadFromFile_Off
-	Private Function LoadFromFile(ByRef FileName As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF) As String
+	Private Function LoadFromFile(ByRef FileName As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF, ByVal nCodePage As Integer = -1) As WString Ptr
 		Dim As String Buff, EncodingStr, NewLineStr
 		Dim As Integer Result = -1, Fn, FileSize, MaxChars
 		Dim As Boolean FileLoaded
@@ -314,10 +314,10 @@ End Function
 		Else
 			CloseFile_(Fn)
 			Debug.Print Date + " " + Time + Chr(9) + __FUNCTION__ +  " Line: " + Str( __LINE__) + Chr(9) + "Open file failure: " + FileName, True
-			Return ""
+			Return 0
 		End If
 		Fn = FreeFile_
-		If FileEncoding = FileEncodings.Utf8 Then
+		If FileEncoding = FileEncodings.Utf8 OrElse FileEncoding = FileEncodings.PlainText Then
 			If FileLoaded Then
 				Result = 0
 			Else
@@ -327,29 +327,47 @@ End Function
 			Result = Open(FileName For Input Encoding EncodingStr As #Fn)
 		End If
 		If Result = 0 Then
-			If FileEncoding = FileEncodings.Utf8 Then
+			If FileEncoding = FileEncodings.Utf8 OrElse FileEncoding = FileEncodings.PlainText Then
 				If FileLoaded Then
-					Function = FromUtf8(StrPtr(Buff))
+					#ifdef __USE_GTK__
+						Return FromUtf8(StrPtr(Buff))
+					#else
+						Dim CodePage As Integer = IIf(nCodePage= -1, GetACP(), nCodePage)
+						Dim As Integer m_BufferLen = MultiByteToWideChar(CodePage, 0, StrPtr(Buff), -1, NULL, 0) - 1
+						Dim As WString Ptr pBuff = CAllocate(m_BufferLen * 2 + 2)
+						MultiByteToWideChar(CodePage, 0, StrPtr(Buff), -1, pBuff, m_BufferLen)
+						Return pBuff
+					#endif
 				Else
 					Buff = String(FileSize, 0)
 					Get #Fn, , Buff
 					CloseFile_(Fn)
-					Return FromUtf8(StrPtr(Buff))
+					#ifdef __USE_GTK__
+						Return FromUtf8(StrPtr(Buff))
+					#else
+						Dim CodePage As Integer = IIf(nCodePage= -1, GetACP(), nCodePage)
+						Dim As Integer m_BufferLen = MultiByteToWideChar(CodePage, 0, StrPtr(Buff), -1, NULL, 0) - 1
+						Dim As WString Ptr pBuff = CAllocate(m_BufferLen * 2 + 2)
+						MultiByteToWideChar(CodePage, 0, StrPtr(Buff), -1, pBuff, m_BufferLen)
+						Return pBuff
+					#endif
 				End If
 			Else
-				Function = WInput(FileSize, #Fn)
+				Dim As WString Ptr pBuff
+				WLet(pBuff, WInput(FileSize, #Fn))
 				CloseFile_(Fn)
+				Return pBuff
 			End If
 		Else
 			CloseFile_(Fn)
 			Debug.Print Date + " " + Time + Chr(9) + __FUNCTION__ +  " Line: " + Str( __LINE__) + Chr(9) + "Open file failure: " + FileName, True
-			Return ""
+			Return 0
 		End If
 	End Function
 #endif
 
 #ifndef SaveToFile_Off
-	Private Function SaveToFile(ByRef FileName As WString, ByRef wData As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF) As Boolean
+	Private Function SaveToFile(ByRef FileName As WString, ByRef wData As WString, ByRef FileEncoding As FileEncodings = FileEncodings.Utf8BOM, ByRef NewLineType As NewLineTypes = NewLineTypes.WindowsCRLF, ByVal nCodePage As Integer = -1) As Boolean
 		Dim As Integer Fn = FreeFile_
 		Dim As Integer Result, MaxChars = Len(wData) - 1
 		Dim As String FileEncodingText, NewLineStr, OldLineStr
@@ -388,18 +406,39 @@ End Function
 		Else
 			NewLineStr = Chr(13, 10)
 		End If
-		If FileEncoding = FileEncodings.Utf8 Then
+		If FileEncoding = FileEncodings.Utf8 OrElse FileEncoding = FileEncodings.PlainText Then
 			Result = Open(FileName For Binary Access Write As #Fn)
 		Else
 			Result = Open(FileName For Output Encoding FileEncodingText As #Fn)
 		End If
 		If  Result = 0 Then
-			If FileEncoding = FileEncodings.Utf8 Then
-				If NewLineStr <> OldLineStr Then
-					Put #Fn, , ToUtf8(Replace(wData, OldLineStr, NewLineStr))
-				Else
-					Put #Fn, , ToUtf8(wData) 'Automaticaly add a Cr LF to the ends of file for each time without ";"
-				End If
+			If FileEncoding = FileEncodings.Utf8 OrElse FileEncoding = FileEncodings.PlainText Then
+				#ifdef __USE_GTK__
+					If NewLineStr <> OldLineStr Then
+						Put #Fn, , ToUtf8(Replace(wData, OldLineStr, NewLineStr))
+					Else
+						Put #Fn, , ToUtf8(wData)
+					End If
+				#else
+					Dim CodePage As Integer = IIf(nCodePage= -1, GetACP(), nCodePage)
+					If NewLineStr <> OldLineStr AndAlso NewLineStr <> Chr(13, 10) Then
+						wData = Replace(wData, OldLineStr, NewLineStr)
+					End If
+					Dim As Integer m_BufferLen = WideCharToMultiByte(CodePage, 0, StrPtr(wData), -1, NULL, 0, NULL, NULL) - 1
+					Dim As ZString Ptr pBuff = CAllocate(m_BufferLen * 2 + 2)
+					WideCharToMultiByte(CodePage, 0, StrPtr(wData), m_BufferLen, pBuff, m_BufferLen, NULL, NULL)
+					Put #Fn, , *pBuff
+					Deallocate(pBuff)
+				#endif
+			'ElseIf FileEncoding = FileEncodings.PlainText Then
+			'	'To prevent right truncation due to the differing lengths of String and WString. THis is ANSI only
+			'	Dim As String bufferOut
+			'	If NewLineStr <> OldLineStr Then
+			'		bufferOut = Replace(wData, OldLineStr, NewLineStr);  'Automaticaly add a Cr LF to the ends of file for each time without ";"
+			'	Else
+			'		bufferOut = wData
+			'	End If
+			'	Print #Fn, bufferOut;
 			Else
 				If NewLineStr <> OldLineStr Then
 					Print #Fn, Replace(wData, OldLineStr, NewLineStr);  'Automaticaly add a Cr LF to the ends of file for each time without ";"

--- a/mff/UString.bas
+++ b/mff/UString.bas
@@ -508,7 +508,7 @@ Private Function ToUtf8(ByRef nWString As WString) As String
 	'#endif
 End Function
 
-Private Function FromUtf8(pZString As ZString Ptr) As String
+Private Function FromUtf8(pZString As ZString Ptr) As WString Ptr
 	'	#ifdef __USE_GTK__
 	'		Return g_locale_from_utf8(*pZString, Len(*pZString), 0, 0, 0)
 	'	#else
@@ -518,12 +518,11 @@ Private Function FromUtf8(pZString As ZString Ptr) As String
 	'UTF-32 little-endian: FF FE 00 00
 	'UTF-32 big-endian: 00 00 FE FF
 	Dim m_BufferLen As Integer = IIf(pZString <> 0, Len(*pZString) + 1, 0)
-	If m_BufferLen = 0 Then Return ""
+	If m_BufferLen = 0 Then Return 0
 	Dim As WString Ptr buffer
 	WReAllocate(buffer, m_BufferLen)
 	*buffer = String(m_BufferLen, 0)
-	Function = WGet(UTFToWChar(1, pZString, buffer, @m_BufferLen))
-	_Deallocate(buffer)
+	Return UTFToWChar(1, pZString, buffer, @m_BufferLen)
 End Function
 
 Private Function ZGet(ByRef subject As ZString Ptr) As String
@@ -704,8 +703,11 @@ Private Function Split Overload(ByRef wszMainStr As String, ByRef Delimiter As C
 	Dim As Integer L2 = CPtr(Integer Ptr, @Delimiter)[1]
 	Dim As Integer i = 0 'UBound(Result) + 1
 	Dim As Integer N, N0 = 1
-	
-	ReDim Preserve Result(LBound(Result) To i + L1 / L2)
+	If L1 < 1 OrElse L2 < 1 Then
+		ReDim Result(0)
+		Return 0
+	End If
+	ReDim Preserve Result(0 To i + L1 / L2) 'LBound(Result)
 	Do
 		If MatchCase Then
 			N = InStr(N0, wszMainStr, Delimiter)
@@ -732,7 +734,7 @@ Private Function Split Overload(ByRef wszMainStr As String, ByRef Delimiter As C
 			Else
 				i -= 1
 			End If
-			ReDim Preserve Result(LBound(Result) To i)
+			ReDim Preserve Result(0 To i)  'LBound(Result)
 			Exit Do
 		End If
 	Loop
@@ -750,7 +752,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 	Dim As Integer i = 0'UBound(Result) + 1
 	Dim As Integer L, n, n0 = 1
 	Dim As WString Ptr p, p1 = @wszMainStr
-	ReDim Preserve Result(LBound(Result) To i + L1 / L2)
+	ReDim Preserve Result(0 To i + L1 / L2) 'LBound(Result)
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
@@ -772,7 +774,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 			Else
 				i -= 1
 			End If
-			ReDim Preserve Result(LBound(Result) To i)
+			ReDim Preserve Result(0 To i) 'LBound(Result)
 			Exit Do
 		End If
 	Loop
@@ -825,7 +827,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 	Dim As Integer i = 0 'UBound(Result) + 1
 	Dim As Integer L, n, n0 = 1
 	Dim As WString Ptr p, p1 = @wszMainStr
-	ReDim Preserve Result(LBound(Result) To i + L1 / L2)
+	ReDim Preserve Result(0 To i + L1 / L2) 'LBound(Result)
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
@@ -847,7 +849,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 			Else
 				i -= 1
 			End If
-			ReDim Preserve Result(LBound(Result) To i)
+			ReDim Preserve Result(0 To i) 'LBound(Result)
 			Exit Do
 		End If
 	Loop
@@ -865,7 +867,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 	Dim As Integer i = 0 'UBound(Result) + 1
 	Dim As Integer L, n, n0 = 1
 	Dim As WString Ptr p, p1 = @wszMainStr
-	ReDim Preserve Result(LBound(Result) To i + L1 / L2)
+	ReDim Preserve Result(0 To i + L1 / L2) 'LBound(Result)
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
@@ -889,7 +891,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 			Else
 				i -= 1
 			End If
-			ReDim Preserve Result(LBound(Result) To i)
+			ReDim Preserve Result(0 To i) 'LBound(Result)
 			Exit Do
 		End If
 	Loop
@@ -949,7 +951,7 @@ Private Function Split(ByRef wszMainStr As ZString, ByRef Delimiter As Const ZSt
 	Dim As Integer i = 0 'UBound(Result) + 1
 	Dim As Integer L, n, n0 = 1
 	Dim As ZString Ptr p, p1 = @wszMainStr
-	ReDim Preserve Result(LBound(Result) To i + L1 / L2)
+	ReDim Preserve Result(0 To i + L1 / L2) 'LBound(Result)
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
@@ -973,7 +975,7 @@ Private Function Split(ByRef wszMainStr As ZString, ByRef Delimiter As Const ZSt
 			Else
 				i -= 1
 			End If
-			ReDim Preserve Result(LBound(Result) To i)
+			ReDim Preserve Result(0 To i) 'LBound(Result)
 			Exit Do
 		End If
 	Loop
@@ -1353,4 +1355,3 @@ End Function
 		#endif
 	End Function
 #endif
-

--- a/mff/UString.bas
+++ b/mff/UString.bas
@@ -508,7 +508,7 @@ Private Function ToUtf8(ByRef nWString As WString) As String
 	'#endif
 End Function
 
-Private Function FromUtf8(pZString As ZString Ptr) ByRef As WString
+Private Function FromUtf8(pZString As ZString Ptr) As String
 	'	#ifdef __USE_GTK__
 	'		Return g_locale_from_utf8(*pZString, Len(*pZString), 0, 0, 0)
 	'	#else
@@ -754,7 +754,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
-			If (skipEmptyElement = 0) OrElse (n - n0) > 0 Then
+			If (Not skipEmptyElement) OrElse (n - n0) > 0 Then
 				p = p1 + n0 - 1
 				L = n - n0
 				Dim As WString * 1 w
@@ -765,7 +765,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 			End If
 			n0 = n + L2
 		Else
-			If (skipEmptyElement = 0) OrElse (L1 - n0 + 1) > 0 Then
+			If (Not skipEmptyElement) OrElse (L1 - n0 + 1) > 0 Then
 				p = p1 + n0 - 1
 				L = L1 - n0 + 1
 				Result(i) = * (p)
@@ -829,7 +829,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
-			If (skipEmptyElement = 0) OrElse (n - n0) > 0 Then
+			If (Not skipEmptyElement) OrElse (n - n0) > 0 Then
 				p = p1 + n0 - 1
 				L = n - n0
 				Dim As WString * 1 w
@@ -840,7 +840,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 			End If
 			n0 = n + L2
 		Else
-			If (skipEmptyElement = 0) OrElse (L1 - n0 + 1) > 0 Then
+			If (Not skipEmptyElement) OrElse (L1 - n0 + 1) > 0 Then
 				p = p1 + n0 - 1
 				L = L1 - n0 + 1
 				Result(i) = * (p)
@@ -869,7 +869,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
-			If (skipEmptyElement = 0) OrElse (n - n0) > 0 Then
+			If (Not skipEmptyElement) OrElse (n - n0) > 0 Then
 				p = p1 + n0 - 1
 				L = n - n0
 				Dim As WString * 1 w
@@ -881,7 +881,7 @@ Private Function Split(ByRef wszMainStr As WString, ByRef Delimiter As Const WSt
 			End If
 			n0 = n + L2
 		Else
-			If (skipEmptyElement = 0) OrElse (L1 - n0 + 1) > 0 Then
+			If (Not skipEmptyElement) OrElse (L1 - n0 + 1) > 0 Then
 				p = p1 + n0 - 1
 				L = L1 - n0 + 1
 				Result(i) = CAllocate((L + 1) * SizeOf(WString))
@@ -953,7 +953,7 @@ Private Function Split(ByRef wszMainStr As ZString, ByRef Delimiter As Const ZSt
 	Do
 		If MatchCase Then n = InStr(n0, wszMainStr, Delimiter) Else n = InStr(n0, LCase(wszMainStr), LCase(Delimiter))
 		If n > 0 Then
-			If (skipEmptyElement = 0) OrElse (n - n0) > 0 Then
+			If (Not skipEmptyElement) OrElse (n - n0) > 0 Then
 				p = p1 + n0 - 1
 				L = n - n0
 				Dim As ZString * 1 w
@@ -965,7 +965,7 @@ Private Function Split(ByRef wszMainStr As ZString, ByRef Delimiter As Const ZSt
 			End If
 			n0 = n + L2
 		Else
-			If (skipEmptyElement = 0) OrElse (L1 - n0 + 1) > 0 Then
+			If (Not skipEmptyElement) OrElse (L1 - n0 + 1) > 0 Then
 				p = p1 + n0 - 1
 				L = L1 - n0 + 1
 				Result(i) = CAllocate((L + 1) * SizeOf(ZString))

--- a/mff/UString.bi
+++ b/mff/UString.bi
@@ -80,7 +80,7 @@ Declare Sub WDeAllocateEx Overload(subject() As WString Ptr)
 Declare Sub WLetEx(ByRef subject As WString Ptr, ByRef txt As WString, ExistsSubjectInTxt As Boolean = True)
 Declare Sub WAdd(ByRef subject As WString Ptr, ByRef txt As WString, AddBefore As Boolean = False)
 Declare Function ToUtf8(ByRef nWString As WString) As String
-Declare Function FromUtf8(pZString As ZString Ptr) ByRef As WString
+Declare Function FromUtf8(pZString As ZString Ptr) As String
 Declare Function Replace(ByRef Expression As WString, ByRef FindingText As WString, ByRef ReplacingText As WString, ByVal Start As Integer = 1, ByVal Count As Integer = -1, MatchCase As Boolean = True, ByRef CountReplaced As Integer = 0) As UString
 Declare Function ZGet(ByRef subject As ZString Ptr) As String
 Declare Function InStrCount(ByRef subject As WString, ByRef searchtext As WString, start As Integer = 1, MatchCase As Boolean = True) As Long

--- a/mff/UString.bi
+++ b/mff/UString.bi
@@ -80,7 +80,7 @@ Declare Sub WDeAllocateEx Overload(subject() As WString Ptr)
 Declare Sub WLetEx(ByRef subject As WString Ptr, ByRef txt As WString, ExistsSubjectInTxt As Boolean = True)
 Declare Sub WAdd(ByRef subject As WString Ptr, ByRef txt As WString, AddBefore As Boolean = False)
 Declare Function ToUtf8(ByRef nWString As WString) As String
-Declare Function FromUtf8(pZString As ZString Ptr) As String
+Declare Function FromUtf8(pZString As ZString Ptr) As WString Ptr
 Declare Function Replace(ByRef Expression As WString, ByRef FindingText As WString, ByRef ReplacingText As WString, ByVal Start As Integer = 1, ByVal Count As Integer = -1, MatchCase As Boolean = True, ByRef CountReplaced As Integer = 0) As UString
 Declare Function ZGet(ByRef subject As ZString Ptr) As String
 Declare Function InStrCount(ByRef subject As WString, ByRef searchtext As WString, start As Integer = 1, MatchCase As Boolean = True) As Long


### PR DESCRIPTION
Must be use "Open FileName For Binary Access Write As #Fn" to save the file as UTF-8 without a BOM. 
Note that there is a bug in the fromUTF8 function.