### PR TITLE
Fixed: IDE crashes when dragging WebBrowse onto forms in Windows 32-bit.

### DIFF
--- a/mff/Control.bas
+++ b/mff/Control.bas
@@ -1073,8 +1073,8 @@ Namespace My.Sys.Forms
 					Dim As Integer AControlParent(2) => {0, WS_EX_CONTROLPARENT}
 					Dim As Integer ATabStop(2) = {0, WS_TABSTOP}, AGrouped(2) = {0, WS_GROUP}
 					If ClassName = "WebBrowser" Then
-						'Style = WS_TABSTOP Or WS_CHILD Or WS_VISIBLE
-						'ExStyle = 0
+						Style = WS_TABSTOP Or WS_CHILD Or WS_VISIBLE
+						ExStyle = 0
 						'					ElseIf ClassName = "IPAddress" Then
 						'						Text = ""
 						'						Style = WS_TABSTOP Or WS_CHILD Or WS_VISIBLE Or WS_OVERLAPPED


### PR DESCRIPTION
XusinboyBekchanov; XusinboyBekchanov; The defaultfont not apply to all control(  {Main.bas|LoadSettings Ln7052}) `
 	pDefaultFont->Name = WGet(InterfaceFontName)
	pDefaultFont->Size  = InterfaceFontSize  
` Could you please fix this?