### PR TITLE
Fix WinAPI ComboBoxEdit selection persistence after dark/light theme toggle

### DIFF
--- a/mff/ComboBoxEdit.bas
+++ b/mff/ComboBoxEdit.bas
@@ -590,6 +590,18 @@ Namespace My.Sys.Forms
 					If txtHandle Then SetWindowTheme(txtHandle, NULL, NULL)
 				End If
 			End If
+			If Style = cbDropDown OrElse Style = cbSimple Then
+				Dim As HWND txtHandle = FEditHandle
+				If txtHandle = 0 OrElse Not IsWindow(txtHandle) Then
+					GetChilds
+					txtHandle = FEditHandle
+				End If
+				If txtHandle <> 0 AndAlso IsWindow(txtHandle) Then
+					Dim As Integer nTextLen = GetWindowTextLength(txtHandle)
+					SendMessage(txtHandle, EM_SETSEL, nTextLen, nTextLen)
+					SendMessage(txtHandle, EM_SCROLLCARET, 0, 0)
+				End If
+			End If
 			'SendMessage FHandle, WM_THEMECHANGED, 0, 0
 		End Sub
 	#endif


### PR DESCRIPTION
When ComboBoxEdit Style=cbDropDown mode and Text is equal to one of the Items,
Text will appear in the selected state during DarkMode LightMode transformation,
which affects the UI aesthetics of the program. I don't want this to happen

```
If Style = cbDropDown OrElse Style = cbSimple Then
	Dim As HWND txtHandle = FEditHandle
	If txtHandle = 0 OrElse Not IsWindow(txtHandle) Then
		GetChilds
		txtHandle = FEditHandle
	End If
	If txtHandle <> 0 AndAlso IsWindow(txtHandle) Then
		Dim As Integer nTextLen = GetWindowTextLength(txtHandle)
		SendMessage(txtHandle, EM_SETSEL, nTextLen, nTextLen)
		SendMessage(txtHandle, EM_SCROLLCARET, 0, 0)
	End If
End If

'SendMessage FHandle, WM_THEMECHANGED, 0, 0

```
